### PR TITLE
Collect the website title

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -97,6 +97,11 @@ export async function getMetaTags(htmlOrUrl: string, prefix = '') {
     }
   }
 
+  // Title is a special case since it's not a meta tag
+  if (doc.title && !prefix) {
+    returnObj.title = doc.title
+  }
+
   return returnObj
 }
 


### PR DESCRIPTION
### Description of the Change

This is a simple addition that enables the script to collect the [title](https://developer.mozilla.org/en-US/docs/Web/API/Document/title) of the website. Since the title is not stored in a `meta` tag, it is currently ignored.

### Why Should This Be here?

Many website still don’t use OpenGraph information so this is a good fallback for OpenGraph’s or Twitter’s `title` information.

### Applicable Issues

https://github.com/khaosdoctor/deno-opengraph/issues/3

Fixes: #3
